### PR TITLE
Add rule-based UCxn annotations and info in the changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ du français annotés en Universal Dependencies.* Traitement Automatique des Lan
 
 # Changelog
 
+* 2024-11-15 v2.15
+  * Construction annotations in the [UCxn](https://github.com/LeonieWeissweiler/UCxn) framework added to MISC
+  
+     This release adds rule-based annotations of Interrogatives, Conditionals, Existentials, and NPN (noun-preposition-noun) constructions on the head of the respective phrase, plus construction elements. The UCxn v1 notation and categories are documented [here](https://github.com/LeonieWeissweiler/UCxn/blob/main/docs/UCxn-v1.pdf).
+
 * 2024-05-15 v2.14
   * Fix validation warnings on flat:foreign
   * Fix many NOUN wrongly tagged as PROPN

--- a/fr_gsd-ud-dev.conllu
+++ b/fr_gsd-ud-dev.conllu
@@ -1,4 +1,3 @@
-# global.columns = ID FORM LEMMA UPOS XPOS FEATS HEAD DEPREL DEPS MISC
 # sent_id = fr-ud-dev_00001
 # text = Aviator, un film sur la vie de Hughes.
 1	Aviator	Aviator	PROPN	_	_	0	root	_	SpaceAfter=No
@@ -32,8 +31,8 @@
 # sent_id = fr-ud-dev_00003
 # text = Mais comment faire dans un contexte structurellement raciste ?
 1	Mais	mais	CCONJ	_	_	3	cc	_	wordform=mais
-2	comment	comment	ADV	_	PronType=Int	3	advmod	_	_
-3	faire	faire	VERB	_	VerbForm=Inf	0	root	_	Subject=Generic
+2	comment	comment	ADV	_	PronType=Int	3	advmod	_	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	faire	faire	VERB	_	VerbForm=Inf	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause|Subject=Generic
 4	dans	dans	ADP	_	_	6	case	_	_
 5	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	contexte	contexte	NOUN	_	Gender=Masc|Number=Sing	3	obl:mod	_	_
@@ -1903,10 +1902,10 @@
 6	deux	deux	NUM	_	Number=Plur	7	nummod	_	_
 7	figures	figure	NOUN	_	Gender=Fem|Number=Plur	9	nsubj	_	_
 8	sont	être	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
-9	congruentes	congruent	ADJ	_	Gender=Fem|Number=Plur	0	root	_	_
+9	congruentes	congruent	ADJ	_	Gender=Fem|Number=Plur	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=9:Conditional-NeutralEpistemic.Apodosis@p
 10	si	si	SCONJ	_	_	12	mark	_	_
 11	elles	eux	PRON	_	Emph=No|Gender=Fem|Number=Plur|Person=3|PronType=Prs	12	nsubj	_	_
-12	ont	avoir	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	advcl	_	_
+12	ont	avoir	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	advcl	_	CxnElt=9:Conditional-NeutralEpistemic.Protasis@f
 13	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 14	même	même	ADJ	_	Gender=Fem|Number=Sing	15	amod	_	_
 15	forme	forme	NOUN	_	Gender=Fem|Number=Sing	12	obj	_	_
@@ -2494,7 +2493,7 @@
 # text = Vous êtes abonné au site ?
 1	Vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	wordform=vous
 2	êtes	être	AUX	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	abonné	abonner	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	_
+3	abonné	abonner	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4-5	au	_	_	_	_	_	_	_	_
 4	à	à	ADP	_	_	6	case	_	_
 5	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
@@ -2645,7 +2644,7 @@
 2	Tu	toi	PRON	_	Emph=No|Number=Sing|Person=2|PronType=Prs	5	nsubj	_	wordform=tu
 3	es	être	AUX	_	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	donc	donc	ADV	_	_	5	advmod	_	_
-5	las	las	ADJ	_	Gender=Masc	0	root	_	_
+5	las	las	ADJ	_	Gender=Masc	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	de	de	ADP	_	_	8	case	_	_
 7	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	corvée	corvée	NOUN	_	Gender=Fem|Number=Sing	5	obl:mod	_	_
@@ -2814,14 +2813,14 @@
 7	,	,	PUNCT	_	_	6	punct	_	_
 8	ne	ne	ADV	_	Polarity=Neg	10	advmod	_	_
 9	sera	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	10	aux:pass	_	_
-10	effectué	effectuer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	_
+10	effectué	effectuer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=10:Conditional-NeutralEpistemic.Apodosis@p
 11	que	que	ADV	_	Polarity=Neg	17	advmod	_	_
 12	si	si	SCONJ	_	_	17	mark	_	_
 13	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
 14	malade	malade	NOUN	_	Gender=Masc|Number=Sing	17	nsubj	_	_
 15	compatible	compatible	ADJ	_	Gender=Masc|Number=Sing	14	amod	_	_
 16	en	en	PRON	_	Emph=No|Person=3|PronType=Prs	19	dep:comp	_	_
-17	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	advcl	_	_
+17	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	advcl	_	CxnElt=10:Conditional-NeutralEpistemic.Protasis@f
 18	effectivement	effectivement	ADV	_	_	17	advmod	_	_
 19	besoin	besoin	NOUN	_	Gender=Masc|Number=Sing	17	obj:lvc	_	_
 20	et	et	CCONJ	_	_	26	cc	_	_
@@ -2951,10 +2950,10 @@
 50	et	et	CCONJ	_	_	56	cc	_	SpaceAfter=No
 51	--	--	PUNCT	_	_	53	punct	_	SpaceAfter=No
 52	si	si	SCONJ	_	_	53	mark	_	_
-53	possible	possible	ADJ	_	Gender=Masc|Number=Sing	56	advcl	_	SpaceAfter=No
+53	possible	possible	ADJ	_	Gender=Masc|Number=Sing	56	advcl	_	CxnElt=56:Conditional-NeutralEpistemic.Protasis@f|SpaceAfter=No
 54	--	--	PUNCT	_	_	53	punct	_	SpaceAfter=No
 55	les	eux	PRON	_	Emph=No|Number=Plur|Person=3|PronType=Prs	56	obj	_	_
-56	relie	relier	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	40	conj	_	_
+56	relie	relier	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	40	conj	_	Cxn=Conditional-NeutralEpistemic|CxnElt=56:Conditional-NeutralEpistemic.Apodosis@p
 57	à	à	ADP	_	_	59	case	_	_
 58	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	59	det	_	_
 59	gènes	gène	NOUN	_	Gender=Masc|Number=Plur	56	obl:arg	_	_
@@ -3181,7 +3180,7 @@
 # text = Sont-ils impuissants, voire incompétents, pour résoudre les problèmes politiques à l'intérieur de leur territoire ?
 1	Sont	être	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	SpaceAfter=No|wordform=sont
 2	-ils	eux	PRON	_	Emph=No|Gender=Masc|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	wordform=ils
-3	impuissants	impuissant	ADJ	_	Gender=Masc|Number=Plur	0	root	_	SpaceAfter=No
+3	impuissants	impuissant	ADJ	_	Gender=Masc|Number=Plur	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 4	,	,	PUNCT	_	_	6	punct	_	_
 5	voire	voire	CCONJ	_	_	6	cc	_	_
 6	incompétents	incompétent	ADJ	_	Gender=Masc|Number=Plur	3	conj	_	SpaceAfter=No
@@ -3877,7 +3876,7 @@
 5	c'	ce	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	8	expl:subj	_	SpaceAfter=No
 6	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
 7	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	peur	peur	NOUN	_	Gender=Fem|Number=Sing	24	advcl	_	_
+8	peur	peur	NOUN	_	Gender=Fem|Number=Sing	24	advcl	_	CxnElt=24:Conditional-NeutralEpistemic.Protasis@f
 9	qui	qui	PRON	_	PronType=Rel	10	nsubj	_	_
 10	conduit	conduire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	advcl:cleft	_	_
 11	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
@@ -3893,7 +3892,7 @@
 21	ce	ce	PRON	_	Gender=Masc|Person=3|PronType=Dem	24	expl:subj	_	_
 22	sont	être	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	cop	_	_
 23	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	24	det	_	_
-24	automates	automate	NOUN	_	Gender=Masc|Number=Plur	0	root	_	_
+24	automates	automate	NOUN	_	Gender=Masc|Number=Plur	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=24:Conditional-NeutralEpistemic.Apodosis@p
 25	qui	qui	PRON	_	PronType=Rel	26	nsubj	_	_
 26	gèrent	gérer	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	advcl:cleft	_	_
 27	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	28	det	_	_
@@ -6112,12 +6111,12 @@
 
 # sent_id = fr-ud-dev_00222
 # text = Pourquoi, mais pourquoi Le bénirais-je ?
-1	Pourquoi	pourquoi	ADV	_	PronType=Int	6	advmod	_	SpaceAfter=No|wordform=pourquoi
+1	Pourquoi	pourquoi	ADV	_	PronType=Int	6	advmod	_	CxnElt=6:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No|wordform=pourquoi
 2	,	,	PUNCT	_	_	4	punct	_	_
 3	mais	mais	CCONJ	_	_	4	cc	_	_
 4	pourquoi	pourquoi	ADV	_	PronType=Int	1	conj	_	_
 5	Le	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	obj	_	wordform=le
-6	bénirais	bénir	VERB	_	Mood=Cnd|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+6	bénirais	bénir	VERB	_	Mood=Cnd|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 7	-je	moi	PRON	_	Emph=No|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	wordform=je
 8	?	?	PUNCT	_	_	6	punct	_	_
 
@@ -6455,8 +6454,8 @@
 
 # sent_id = fr-ud-dev_00233
 # text = Comment remédier aux contradictions et au désarroi des relations humaines ?
-1	Comment	comment	ADV	_	PronType=Int	2	advmod	_	wordform=comment
-2	remédier	remédier	VERB	_	VerbForm=Inf	0	root	_	Subject=Generic
+1	Comment	comment	ADV	_	PronType=Int	2	advmod	_	CxnElt=2:Interrogative-WHInfo-Direct.WHWord|wordform=comment
+2	remédier	remédier	VERB	_	VerbForm=Inf	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause|Subject=Generic
 3-4	aux	_	_	_	_	_	_	_	_
 3	à	à	ADP	_	_	5	case	_	_
 4	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
@@ -7567,11 +7566,11 @@
 12	:	:	PUNCT	_	_	15	punct	_	_
 13	Maria	Maria	PROPN	_	_	15	nsubj	_	_
 14	se	soi	PRON	_	Person=3|PronType=Prs|Reflex=Yes	15	expl:pv	_	_
-15	suicide	suicider	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	parataxis	_	SpaceAfter=No
+15	suicide	suicider	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	parataxis	_	Cxn=Interrogative-Alternative|CxnElt=15:Interrogative-Alternative.Choice1,15:Interrogative-Alternative.Clause|SpaceAfter=No
 16	-t-elle	lui	PRON	_	Emph=No|Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	expl:subj	_	wordform=elle
 17	ou	ou	CCONJ	_	_	19	cc	_	_
 18	s'	soi	PRON	_	Person=3|PronType=Prs|Reflex=Yes	19	expl:pv	_	SpaceAfter=No
-19	agit	agir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	conj	_	SpaceAfter=No
+19	agit	agir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	conj	_	CxnElt=15:Interrogative-Alternative.Choice2|SpaceAfter=No
 20	-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	expl:subj	_	wordform=il
 21	d'	de	ADP	_	_	23	case	_	SpaceAfter=No
 22	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
@@ -8960,9 +8959,9 @@
 
 # sent_id = fr-ud-dev_00322
 # text = Couche par couche, Morin arrange les beats digitaux avec les sons des loops des guitares.
-1	Couche	couche	NOUN	_	Gender=Fem|Number=Sing	6	obl:mod	_	wordform=couche
-2	par	par	ADP	_	_	3	case	_	_
-3	couche	couche	NOUN	_	Gender=Fem|Number=Sing	1	nmod	_	SpaceAfter=No
+1	Couche	couche	NOUN	_	Gender=Fem|Number=Sing	6	obl:mod	_	Cxn=NPN|CxnElt=1:NPN.N1|wordform=couche
+2	par	par	ADP	_	_	3	case	_	CxnElt=1:NPN.P
+3	couche	couche	NOUN	_	Gender=Fem|Number=Sing	1	nmod	_	CxnElt=1:NPN.N2|SpaceAfter=No
 4	,	,	PUNCT	_	_	1	punct	_	_
 5	Morin	Morin	PROPN	_	_	6	nsubj	_	_
 6	arrange	arranger	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
@@ -9052,7 +9051,7 @@
 
 # sent_id = fr-ud-dev_00325
 # text = Qu'est-ce qui va augmenter ?
-1	Qu'	que	PRON	_	PronType=Int	0	root	_	SpaceAfter=No|wordform=qu'
+1	Qu'	que	PRON	_	PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No|wordform=qu'
 2	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	SpaceAfter=No
 3	-ce	ce	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	1	expl:subj	_	wordform=ce
 4	qui	qui	PRON	_	PronType=Rel	5	nsubj	_	_
@@ -9550,10 +9549,10 @@
 20	ONU	ONU	PROPN	_	Number=Sing	17	nmod	_	SpaceAfter=No
 21	,	,	PUNCT	_	_	22	punct	_	_
 22	que	que	PRON	_	PronType=Int	26	obj	_	_
-23	pouvez	pouvoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	15	parataxis:insert	_	SpaceAfter=No
+23	pouvez	pouvoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	15	parataxis:insert	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=23:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 24	-vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	23	nsubj	_	wordform=vous
 25	leur	eux	PRON	_	Emph=No|Number=Plur|Person=3|PronType=Prs	26	iobj	_	_
-26	apporter	apporter	VERB	_	VerbForm=Inf	23	xcomp	_	Subject=SubjRaising
+26	apporter	apporter	VERB	_	VerbForm=Inf	23	xcomp	_	CxnElt=23:Interrogative-WHInfo-Direct.WHWord|Subject=SubjRaising
 27	?	?	PUNCT	_	_	23	punct	_	SpaceAfter=No
 28	"	"	PUNCT	_	_	15	punct	_	_
 
@@ -9612,7 +9611,7 @@
 
 # sent_id = fr-ud-dev_00347
 # text = Pourquoi, d'ailleurs, les préservatifs seraient-ils détenus par la femme, alors qu'ils concernent l'homme ?
-1	Pourquoi	pourquoi	ADV	_	PronType=Int	10	advmod	_	SpaceAfter=No|wordform=pourquoi
+1	Pourquoi	pourquoi	ADV	_	PronType=Int	10	advmod	_	CxnElt=10:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No|wordform=pourquoi
 2	,	,	PUNCT	_	_	1	punct	_	_
 3	d'	de	ADP	_	ExtPos=ADV	10	advmod	_	Idiom=Yes|SpaceAfter=No
 4	ailleurs	ailleurs	ADV	_	_	3	fixed	_	InIdiom=Yes|SpaceAfter=No
@@ -9621,7 +9620,7 @@
 7	préservatifs	préservatif	NOUN	_	Gender=Masc|Number=Plur	10	nsubj:pass	_	_
 8	seraient	être	AUX	_	Mood=Cnd|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	_	SpaceAfter=No
 9	-ils	eux	PRON	_	Emph=No|Gender=Masc|Number=Plur|Person=3|PronType=Prs	10	expl:subj	_	wordform=ils
-10	détenus	détenir	VERB	_	Gender=Masc|Number=Plur|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	_
+10	détenus	détenir	VERB	_	Gender=Masc|Number=Plur|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=10:Interrogative-WHInfo-Direct.Clause
 11	par	par	ADP	_	_	13	case	_	_
 12	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	femme	femme	NOUN	_	Gender=Fem|Number=Sing	10	obl:agent	_	SpaceAfter=No
@@ -9887,7 +9886,7 @@
 3	époque	époque	NOUN	_	Gender=Fem|Number=Sing	6	obl:mod	_	SpaceAfter=No
 4	,	,	PUNCT	_	_	3	punct	_	_
 5	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
-6	remarqua	remarquer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	remarqua	remarquer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=6:Conditional-NeutralEpistemic.Apodosis@p
 7	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	8	det	_	_
 8	différences	différence	NOUN	_	Gender=Fem|Number=Plur	6	obj	_	_
 9	de	de	ADP	_	_	10	case	_	_
@@ -9895,7 +9894,7 @@
 11	,	,	PUNCT	_	_	14	punct	_	_
 12	si	si	SCONJ	_	_	14	mark	_	_
 13	on	on	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Ind	14	nsubj	_	_
-14	frappait	frapper	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	6	advcl	_	_
+14	frappait	frapper	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	6	advcl	_	CxnElt=6:Conditional-NeutralEpistemic.Protasis@f
 15	à	à	ADP	_	_	17	case	_	_
 16	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	17	det	_	_
 17	endroits	endroit	NOUN	_	Gender=Masc|Number=Plur	14	obl:arg	_	_
@@ -11437,7 +11436,7 @@
 36	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	39	aux:tense	_	_
 37	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	39	nsubj	_	_
 38	pas	pas	ADV	_	Polarity=Neg	39	advmod	_	_
-39	sorti	sortir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	26	ccomp	_	SpaceAfter=No
+39	sorti	sortir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	26	ccomp	_	Cxn=Interrogative-Polar-Direct|CxnElt=39:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 40	,	,	PUNCT	_	_	42	punct	_	_
 41	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	42	det	_	_
 42	Pan	Pan	PROPN	_	Gender=Masc|Number=Sing	39	dislocated	_	_
@@ -11836,9 +11835,9 @@
 4	qu'	que	SCONJ	_	_	7	mark	_	SpaceAfter=No
 5	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	expl:subj	_	_
 6	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	7	expl:comp	_	_
-7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl,Interrogative-Polar-Direct|CxnElt=7:Interrogative-Polar-Direct.Clause
 8	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	poème	poème	NOUN	_	Gender=Masc|Number=Sing	7	obj	_	_
+9	poème	poème	NOUN	_	Gender=Masc|Number=Sing	7	obj	_	CxnElt=7:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 10	ce	ce	DET	_	Gender=Masc|Number=Sing|PronType=Dem	11	det	_	_
 11	matin	matin	NOUN	_	Gender=Masc|Number=Sing	7	obl:mod	_	_
 12	?	?	PUNCT	_	_	7	punct	_	_
@@ -12067,7 +12066,7 @@
 10	sections	section	NOUN	_	Gender=Fem|Number=Plur	7	obl:mod	_	_
 11	précédentes	précédent	ADJ	_	Gender=Fem|Number=Plur	10	amod	_	SpaceAfter=No
 12	,	,	PUNCT	_	_	2	punct	_	_
-13	quel	quel	ADJ	_	Gender=Masc|Number=Sing|PronType=Int	0	root	_	_
+13	quel	quel	ADJ	_	Gender=Masc|Number=Sing|PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=13:Interrogative-WHInfo-Direct.Clause,13:Interrogative-WHInfo-Direct.WHWord
 14	serait	être	AUX	_	Mood=Cnd|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	SpaceAfter=No
 15	,	,	PUNCT	_	_	17	punct	_	_
 16	en	en	ADP	_	_	17	mark	_	_
@@ -12583,7 +12582,7 @@
 6	s'	si	SCONJ	_	_	9	mark	_	SpaceAfter=No
 7	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
 8	se	soi	PRON	_	Person=3|PronType=Prs|Reflex=Yes	9	expl:pv	_	_
-9	rend	rendre	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
+9	rend	rendre	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	Cxn=Interrogative-Polar-Indirect|CxnElt=9:Interrogative-Polar-Indirect.Clause
 10	à	à	ADP	_	_	11	case	_	_
 11	Petrograd	Petrograd	PROPN	_	_	9	obl:arg	_	SpaceAfter=No
 12	,	,	PUNCT	_	_	14	punct	_	_
@@ -12766,7 +12765,7 @@
 8	de	de	ADP	_	_	10	case	_	_
 9	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
 10	SGF	SGF	PROPN	_	Gender=Fem|Number=Sing	7	nmod	_	_
-11	considèrent	considérer	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	_	_
+11	considèrent	considérer	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	_	CxnElt=21:Conditional-NeutralEpistemic.Protasis@f
 12	ce	ce	DET	_	Gender=Masc|Number=Sing|PronType=Dem	13	det	_	_
 13	militaire	militaire	NOUN	_	Gender=Masc|Number=Sing	11	obj	_	_
 14	avec	avec	ADP	_	_	15	case	_	_
@@ -12776,7 +12775,7 @@
 18	militaires	militaire	NOUN	_	Gender=Masc|Number=Plur	21	nsubj	_	_
 19	inversement	inversement	ADV	_	_	21	advmod	_	_
 20	ne	ne	ADV	_	Polarity=Neg	21	advmod	_	_
-21	comprennent	comprendre	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+21	comprennent	comprendre	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=21:Conditional-NeutralEpistemic.Apodosis@p
 22	pas	pas	ADV	_	Polarity=Neg	23	advmod	_	_
 23	toujours	toujours	ADV	_	_	21	advmod	_	_
 24	cet	ce	DET	_	Gender=Masc|Number=Sing|PronType=Dem	25	det	_	_
@@ -14112,10 +14111,10 @@
 14	s'	si	SCONJ	_	_	17	mark	_	SpaceAfter=No
 15	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
 16	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	cop	_	_
-17	fragile	fragile	ADJ	_	Gender=Masc|Number=Sing	20	advcl	_	SpaceAfter=No
+17	fragile	fragile	ADJ	_	Gender=Masc|Number=Sing	20	advcl	_	CxnElt=20:Conditional-NeutralEpistemic.Protasis@f|SpaceAfter=No
 18	,	,	PUNCT	_	_	17	punct	_	_
 19	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
-20	demeure	demeurer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	_	_
+20	demeure	demeurer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	_	Cxn=Conditional-NeutralEpistemic|CxnElt=20:Conditional-NeutralEpistemic.Apodosis@p
 21	alerte	alerte	ADJ	_	Gender=Masc|Number=Sing	20	xcomp	_	SpaceAfter=No
 22	,	,	PUNCT	_	_	27	punct	_	_
 23	12	12	NUM	_	Number=Plur	24	nummod	_	_
@@ -14751,7 +14750,7 @@
 17	si	si	SCONJ	_	_	20	mark	_	_
 18	je	moi	PRON	_	Emph=No|Number=Sing|Person=1|PronType=Prs	20	nsubj	_	_
 19	serais	être	AUX	_	Mood=Cnd|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	20	cop	_	_
-20	prêt	prêt	ADJ	_	Gender=Masc|Number=Sing	16	ccomp	_	_
+20	prêt	prêt	ADJ	_	Gender=Masc|Number=Sing	16	ccomp	_	Cxn=Interrogative-Polar-Indirect|CxnElt=20:Interrogative-Polar-Indirect.Clause
 21	à	à	ADP	_	_	23	mark	_	_
 22	les	eux	PRON	_	Emph=No|Number=Plur|Person=3|PronType=Prs	23	obj	_	_
 23	rejoindre	rejoindre	VERB	_	VerbForm=Inf	20	xcomp	_	Subject=SubjRaising
@@ -14825,7 +14824,7 @@
 
 # sent_id = fr-ud-dev_00533
 # text = Quels sont les objectifs à long terme et les stratégies à développer ?
-1	Quels	quel	ADJ	_	Gender=Masc|Number=Plur|PronType=Int	0	root	_	wordform=quels
+1	Quels	quel	ADJ	_	Gender=Masc|Number=Plur|PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|wordform=quels
 2	sont	être	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	_
 3	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	4	det	_	_
 4	objectifs	objectif	NOUN	_	Gender=Masc|Number=Plur	1	nsubj	_	_
@@ -16572,7 +16571,7 @@
 4	de	de	ADP	_	_	6	case	_	_
 5	certains	certain	DET	_	Gender=Masc|Number=Plur|PronType=Ind	6	det	_	_
 6	États	état	NOUN	_	Gender=Masc|Number=Plur	3	nmod	_	wordform=états
-7	est	être	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	36	advcl	_	_
+7	est	être	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	36	advcl	_	CxnElt=36:Conditional-NeutralEpistemic.Protasis@f
 8	indiscutablement	indiscutablement	ADV	_	_	7	advmod	_	_
 9	sur	sur	ADP	_	_	11	case	_	_
 10	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
@@ -16601,7 +16600,7 @@
 33	autres	autre	PRON	_	Number=Plur|Person=3|PronType=Ind	25	nmod	_	_
 34	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	36	aux:pass	_	_
 35	moins	moins	ADV	_	_	36	advmod	_	_
-36	tranchée	trancher	VERB	_	Gender=Fem|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	SpaceAfter=No
+36	tranchée	trancher	VERB	_	Gender=Fem|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=36:Conditional-NeutralEpistemic.Apodosis@p|SpaceAfter=No
 37	.	.	PUNCT	_	_	36	punct	_	_
 
 # sent_id = fr-ud-dev_00596
@@ -16672,9 +16671,9 @@
 2	Zran	Zran	PROPN	_	_	1	flat:name	_	_
 3	sait	savoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	de	de	ADP	_	_	5	case	_	_
-5	quoi	quoi	PRON	_	PronType=Int	7	obl:arg	_	_
+5	quoi	quoi	PRON	_	PronType=Int	7	obl:arg	_	CxnElt=7:Interrogative-WHInfo-Indirect.WHWord
 6	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
-7	parle	parler	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	SpaceAfter=No
+7	parle	parler	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=7:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 8	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = fr-ud-dev_00599
@@ -16772,7 +16771,7 @@
 
 # sent_id = fr-ud-dev_00602
 # text = Va-t-il se circonscrire à cette seule matière ?
-1	Va	aller	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No|wordform=va
+1	Va	aller	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause|SpaceAfter=No|wordform=va
 2	-t-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	nsubj	_	wordform=il
 3	se	soi	PRON	_	Person=3|PronType=Prs|Reflex=Yes	4	expl:pass	_	_
 4	circonscrire	circonscrire	VERB	_	VerbForm=Inf	1	xcomp	_	Subject=SubjRaising
@@ -16894,10 +16893,10 @@
 12	,	,	PUNCT	_	_	1	punct	_	_
 13	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	expl:subj	_	_
 14	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	15	expl:comp	_	_
-15	avait	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	0	root	_	_
+15	avait	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 16	encore	encore	ADV	_	_	15	advmod	_	_
 17	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	18	det	_	_
-18	épidémies	épidémie	NOUN	_	Gender=Fem|Number=Plur	15	obj	_	_
+18	épidémies	épidémie	NOUN	_	Gender=Fem|Number=Plur	15	obj	_	CxnElt=15:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 19	de	de	ADP	_	_	20	case	_	_
 20	choléra	choléra	NOUN	_	Gender=Masc|Number=Sing	18	nmod	_	_
 21	en	en	ADP	_	_	22	case	_	_
@@ -17579,14 +17578,14 @@
 13	soldats	soldat	NOUN	_	Gender=Masc|Number=Plur	8	obl:arg	_	_
 14	:	:	PUNCT	_	_	17	punct	_	_
 15	«	«	PUNCT	_	_	17	punct	_	_
-16	pourquoi	pourquoi	ADV	_	PronType=Int	17	advmod	_	_
-17	chanter	chanter	VERB	_	VerbForm=Inf	8	ccomp	_	Subject=Generic
+16	pourquoi	pourquoi	ADV	_	PronType=Int	17	advmod	_	CxnElt=17:Interrogative-WHInfo-Direct.WHWord
+17	chanter	chanter	VERB	_	VerbForm=Inf	8	ccomp	_	Cxn=Conditional-NeutralEpistemic,Interrogative-WHInfo-Direct|CxnElt=17:Conditional-NeutralEpistemic.Apodosis@p,17:Interrogative-WHInfo-Direct.Clause|Subject=Generic
 18	Roland	Roland	PROPN	_	_	17	obj	_	_
 19	s'	si	SCONJ	_	_	23	mark	_	SpaceAfter=No
 20	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	expl:subj	_	_
 21	n'	ne	ADV	_	Polarity=Neg	23	advmod	_	SpaceAfter=No
 22	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	23	expl:comp	_	_
-23	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	advcl	_	_
+23	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	advcl	_	CxnElt=17:Conditional-NeutralEpistemic.Protasis@f
 24	plus	plus	ADV	_	Polarity=Neg	23	advmod	_	_
 25	de	un	DET	_	Definite=Ind|Number=Sing|PronType=Art	26	det	_	_
 26	Roland	Roland	PROPN	_	Number=Sing	23	obj	_	_
@@ -17741,7 +17740,7 @@
 # text = Si vous avez envie de manger dans un endroit où l'hygiène laisse à désirer, je vous conseille vivement ce restaurant.
 1	Si	si	SCONJ	_	_	3	mark	_	wordform=si
 2	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	_
-3	avez	avoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	19	advcl	_	_
+3	avez	avoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	19	advcl	_	CxnElt=19:Conditional-NeutralEpistemic.Protasis@f
 4	envie	envie	NOUN	_	Gender=Fem|Number=Sing	3	obj:lvc	_	_
 5	de	de	ADP	_	_	6	mark	_	_
 6	manger	manger	VERB	_	VerbForm=Inf	4	xcomp	_	Subject=SubjRaising
@@ -17757,7 +17756,7 @@
 16	,	,	PUNCT	_	_	3	punct	_	_
 17	je	moi	PRON	_	Emph=No|Number=Sing|Person=1|PronType=Prs	19	nsubj	_	_
 18	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	19	iobj	_	_
-19	conseille	conseiller	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+19	conseille	conseiller	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=19:Conditional-NeutralEpistemic.Apodosis@p
 20	vivement	vivement	ADV	_	_	19	advmod	_	_
 21	ce	ce	DET	_	Gender=Masc|Number=Sing|PronType=Dem	22	det	_	_
 22	restaurant	restaurant	NOUN	_	Gender=Masc|Number=Sing	19	obj	_	SpaceAfter=No
@@ -17854,7 +17853,7 @@
 
 # sent_id = fr-ud-dev_00642
 # text = Laquelle a-t-elle été ?
-1	Laquelle	lequel	PRON	_	Gender=Fem|Number=Sing|PronType=Int	0	root	_	wordform=laquelle
+1	Laquelle	lequel	PRON	_	Gender=Fem|Number=Sing|PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|wordform=laquelle
 2	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	aux:tense	_	SpaceAfter=No
 3	-t-elle	lui	PRON	_	Emph=No|Gender=Fem|Number=Sing|Person=3|PronType=Prs	1	nsubj	_	wordform=elle
 4	été	être	AUX	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part	1	cop	_	_
@@ -17895,7 +17894,7 @@
 # sent_id = fr-ud-dev_00644
 # text = Mais quel est son rapport au christianisme ?
 1	Mais	mais	CCONJ	_	_	2	cc	_	wordform=mais
-2	quel	quel	ADJ	_	Gender=Masc|Number=Sing|PronType=Int	0	root	_	_
+2	quel	quel	ADJ	_	Gender=Masc|Number=Sing|PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause,2:Interrogative-WHInfo-Direct.WHWord
 3	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	cop	_	_
 4	son	son	DET	_	Number=Sing|Number[psor]=Sing|Person[psor]=3|Poss=Yes|PronType=Prs	5	det	_	_
 5	rapport	rapport	NOUN	_	Gender=Masc|Number=Sing	2	nsubj	_	_
@@ -18231,7 +18230,7 @@
 3	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux:tense	_	SpaceAfter=No
 4	-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	expl:subj	_	wordform=il
 5	pas	pas	ADV	_	Polarity=Neg	6	advmod	_	_
-6	devenu	devenir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	_
+6	devenu	devenir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause
 7	son	son	DET	_	Number=Sing|Number[psor]=Sing|Person[psor]=3|Poss=Yes|PronType=Prs	9	det	_	_
 8	propre	propre	ADJ	_	Gender=Masc|Number=Sing	9	amod	_	_
 9	adversaire	adversaire	NOUN	_	Gender=Masc|Number=Sing	6	xcomp	_	_
@@ -18781,11 +18780,11 @@
 17	demande	demander	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
 18	de	de	ADP	_	_	20	mark	_	_
 19	le	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	obj	_	_
-20	trouver	trouver	VERB	_	VerbForm=Inf	17	xcomp	_	Subject=OblRaising
+20	trouver	trouver	VERB	_	VerbForm=Inf	17	xcomp	_	Cxn=Conditional-NeutralEpistemic|CxnElt=20:Conditional-NeutralEpistemic.Apodosis@p|Subject=OblRaising
 21	si	si	SCONJ	_	_	24	mark	_	_
 22	jamais	jamais	ADV	_	Polarity=Pos	24	advmod	_	_
 23	elle	lui	PRON	_	Emph=No|Gender=Fem|Number=Sing|Person=3|PronType=Prs	24	nsubj	_	_
-24	vient	venir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	advcl	_	_
+24	vient	venir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	advcl	_	CxnElt=20:Conditional-NeutralEpistemic.Protasis@f
 25	à	à	ADP	_	_	26	case	_	_
 26	Tokyo	Tokyo	PROPN	_	_	24	obl:arg	_	SpaceAfter=No
 27	.	.	PUNCT	_	_	2	punct	_	_
@@ -18802,12 +18801,12 @@
 8	,	,	PUNCT	_	_	3	punct	_	_
 9	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	expl:subj	_	_
 10	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	11	expl:comp	_	_
-11	avait	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	0	root	_	_
+11	avait	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 12	cette	ce	DET	_	Gender=Fem|Number=Sing|PronType=Dem	13	det	_	_
 13	année	année	NOUN	_	Gender=Fem|Number=Sing	11	obl:mod	_	_
 14	de	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	16	det	_	_
 15	nombreux	nombreux	ADJ	_	Gender=Masc|Number=Plur	16	amod	_	_
-16	programmes	programme	NOUN	_	Gender=Masc|Number=Plur	11	obj	_	_
+16	programmes	programme	NOUN	_	Gender=Masc|Number=Plur	11	obj	_	CxnElt=11:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 17	très	très	ADV	_	_	18	advmod	_	_
 18	intéressants	intéressant	ADJ	_	Gender=Masc|Number=Plur	16	amod	_	_
 19	et	et	CCONJ	_	_	24	cc	_	_
@@ -19196,7 +19195,7 @@
 # sent_id = fr-ud-dev_00690
 # text = Vous vouliez visiter le Mont Rushmore et vous vous êtes égarés ?...
 1	Vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	2	nsubj	_	wordform=vous
-2	vouliez	vouloir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Imp|VerbForm=Fin	0	root	_	_
+2	vouliez	vouloir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Imp|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	visiter	visiter	VERB	_	VerbForm=Inf	2	xcomp	_	Subject=SubjRaising
 4	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 5	Mont	Mont	PROPN	_	Gender=Masc|Number=Sing	3	obj	_	_
@@ -19878,10 +19877,10 @@
 # text = Il y a donc le monde de la réalité comprenant les nobles et les artisans et le monde de la magie.
 1	Il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	expl:subj	_	wordform=il
 2	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	3	expl:comp	_	_
-3	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 4	donc	donc	ADV	_	_	3	advmod	_	_
 5	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	monde	monde	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	_
+6	monde	monde	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	CxnElt=3:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 7	de	de	ADP	_	_	9	case	_	_
 8	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	réalité	réalité	NOUN	_	Gender=Fem|Number=Sing	6	nmod	_	_
@@ -20202,10 +20201,10 @@
 4	-ci	ci	ADV	_	_	3	advmod	_	SpaceAfter=No|wordform=ci
 5	,	,	PUNCT	_	_	3	punct	_	_
 6	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	7	expl:comp	_	_
-7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 8	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 9	autre	autre	ADJ	_	Gender=Masc|Number=Sing	10	amod	_	_
-10	élément	élément	NOUN	_	Gender=Masc|Number=Sing	7	obj	_	_
+10	élément	élément	NOUN	_	Gender=Masc|Number=Sing	7	obj	_	CxnElt=7:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 11	qui	qui	PRON	_	PronType=Rel	12	nsubj	_	_
 12	intervient	intervenir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	_	_
 13	dans	dans	ADP	_	_	15	case	_	_
@@ -20931,10 +20930,10 @@
 27	ne	ne	ADV	_	Polarity=Neg	28	advmod	_	_
 28	sait	savoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	acl:relcl	_	_
 29	pas	pas	ADV	_	Polarity=Neg	28	advmod	_	_
-30	comment	comment	ADV	_	PronType=Int	33	obl:arg	_	_
+30	comment	comment	ADV	_	PronType=Int	33	obl:arg	_	CxnElt=33:Interrogative-WHInfo-Indirect.WHWord
 31	s'	soi	PRON	_	Person=3|PronType=Prs|Reflex=Yes	33	expl:pv	_	SpaceAfter=No
 32	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	33	expl:comp	_	_
-33	prendre	prendre	VERB	_	VerbForm=Inf	28	xcomp	_	SpaceAfter=No|Subject=SubjRaising
+33	prendre	prendre	VERB	_	VerbForm=Inf	28	xcomp	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=33:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No|Subject=SubjRaising
 34	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = fr-ud-dev_00759
@@ -22923,7 +22922,7 @@
 2	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
 3	tableau	tableau	NOUN	_	Gender=Masc|Number=Sing	5	nsubj:pass	_	_
 4	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux:pass	_	_
-5	exposé	exposer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	18	advcl	_	_
+5	exposé	exposer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	18	advcl	_	CxnElt=18:Conditional-NeutralEpistemic.Protasis@f
 6	à	à	ADP	_	_	7	case	_	_
 7	New	New	PROPN	_	_	5	obl:mod	_	_
 8	York	York	PROPN	_	_	7	flat:name	_	SpaceAfter=No
@@ -22936,7 +22935,7 @@
 15	polychrome	polychrome	ADJ	_	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	_	_	14	punct	_	_
 17	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux:tense	_	_
-18	resté	rester	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	_
+18	resté	rester	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=18:Conditional-NeutralEpistemic.Apodosis@p
 19	sur	sur	ADP	_	_	20	case	_	_
 20	place	place	NOUN	_	Gender=Fem|Number=Sing	18	obl:mod	_	SpaceAfter=No
 21	.	.	PUNCT	_	_	18	punct	_	_
@@ -23379,7 +23378,7 @@
 # text = Comment Lui dirais-je : Béni sois-Tu, l'Éternel, Maître de l'Univers, qui nous a élus parmi les peuples pour être torturés jour et nuit, pour voir nos pères, nos mères, nos frères finir au crématoire ?
 1	Comment	comment	ADV	_	_	3	advmod	_	wordform=comment
 2	Lui	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	iobj	_	wordform=lui
-3	dirais	dire	VERB	_	Mood=Cnd|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+3	dirais	dire	VERB	_	Mood=Cnd|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 4	-je	moi	PRON	_	Emph=No|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	wordform=je
 5	:	:	PUNCT	_	_	6	punct	_	_
 6	Béni	bénir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	3	ccomp	_	wordform=béni
@@ -23906,7 +23905,7 @@
 3	suivante	suivant	ADJ	_	Gender=Fem|Number=Sing	2	amod	_	_
 4	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
 5	:	:	PUNCT	_	_	6	punct	_	_
-6	Peut	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No|wordform=peut
+6	Peut	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause|SpaceAfter=No|wordform=peut
 7	-on	on	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Ind	6	nsubj	_	wordform=on
 8	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	9	obl:mod	_	_
 9	prendre	prendre	VERB	_	VerbForm=Inf	6	xcomp	_	Subject=SubjRaising
@@ -24227,7 +24226,7 @@
 1	Ainsi	ainsi	ADV	_	_	4	advmod	_	SpaceAfter=No|wordform=ainsi
 2	,	,	PUNCT	_	_	1	punct	_	_
 3	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	expl:subj	_	_
-4	conviendra	convenir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
+4	conviendra	convenir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=4:Conditional-NeutralEpistemic.Apodosis@p
 5	de	de	ADP	_	_	6	mark	_	_
 6	regarder	regarder	VERB	_	VerbForm=Inf	4	csubj	_	Subject=Generic
 7	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
@@ -24240,7 +24239,7 @@
 14	n'	ne	ADV	_	Polarity=Neg	17	advmod	_	SpaceAfter=No
 15	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
 16	pas	pas	ADV	_	Polarity=Neg	17	advmod	_	_
-17	rempli	remplir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	4	advcl	_	_
+17	rempli	remplir	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	4	advcl	_	CxnElt=4:Conditional-NeutralEpistemic.Protasis@f
 18	et	et	CCONJ	_	_	19	cc	_	_
 19	ainsi	ainsi	ADV	_	ExtPos=ADV	17	conj	_	Idiom=Yes
 20	de	de	ADP	_	_	19	fixed	_	InIdiom=Yes
@@ -27028,7 +27027,7 @@
 29	sommes	être	AUX	_	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	32	cop	_	SpaceAfter=No
 30	-nous	nous	PRON	_	Emph=No|Number=Plur|Person=1|PronType=Prs	32	nsubj	_	wordform=nous
 31	encore	encore	ADV	_	_	32	advmod	_	_
-32	R.E.M.	R.E.M.	PROPN	_	_	3	parataxis	_	_
+32	R.E.M.	R.E.M.	PROPN	_	_	3	parataxis	_	Cxn=Interrogative-Polar-Direct|CxnElt=32:Interrogative-Polar-Direct.Clause
 33	?	?	PUNCT	_	_	32	punct	_	_
 
 # sent_id = fr-ud-dev_00977
@@ -27113,10 +27112,10 @@
 1-2	Au	_	_	_	_	_	_	_	_
 1	à	à	ADP	_	_	3	case	_	_
 2	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	nom	nom	NOUN	_	Gender=Masc|Number=Sing	6	obl:mod	_	_
+3	nom	nom	NOUN	_	Gender=Masc|Number=Sing	6	obl:mod	_	CxnElt=6:Interrogative-WHInfo-Direct.WHWord
 4	de	de	ADP	_	_	5	case	_	_
 5	quoi	quoi	PRON	_	PronType=Int	3	nmod	_	_
-6	refuser	refuser	VERB	_	VerbForm=Inf	0	root	_	Subject=Generic
+6	refuser	refuser	VERB	_	VerbForm=Inf	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause|Subject=Generic
 7	telle	tel	DET	_	Gender=Fem|Number=Sing|PronType=Ind	8	det	_	_
 8	pratique	pratique	NOUN	_	Gender=Fem|Number=Sing	6	obj	_	_
 9	et	et	CCONJ	_	_	10	cc	_	_
@@ -28443,10 +28442,10 @@
 1	Il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	expl:subj	_	wordform=il
 2	n'	ne	ADV	_	Polarity=Neg	4	advmod	_	SpaceAfter=No
 3	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	4	expl:comp	_	_
-4	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 5	pas	pas	ADV	_	Polarity=Neg	4	advmod	_	_
 6	de	un	DET	_	Definite=Ind|Number=Sing|PronType=Art	7	det	_	_
-7	relégation	relégation	NOUN	_	Gender=Fem|Number=Sing	4	obj	_	SpaceAfter=No
+7	relégation	relégation	NOUN	_	Gender=Fem|Number=Sing	4	obj	_	CxnElt=4:Existential-HavePred-ItExpl-ThereExpl.Pivot@f|SpaceAfter=No
 8	,	,	PUNCT	_	_	12	punct	_	_
 9	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
 10	championnat	championnat	NOUN	_	Gender=Masc|Number=Sing	12	nsubj:pass	_	_
@@ -29120,12 +29119,12 @@
 11	qu'	que	SCONJ	_	_	13	mark	_	SpaceAfter=No
 12	Hermia	Hermia	PROPN	_	_	13	nsubj	_	_
 13	peut	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	_	_
-14	épouser	épouser	VERB	_	VerbForm=Inf	13	xcomp	_	Subject=SubjRaising
+14	épouser	épouser	VERB	_	VerbForm=Inf	13	xcomp	_	Cxn=Conditional-NeutralEpistemic|CxnElt=14:Conditional-NeutralEpistemic.Apodosis@p|Subject=SubjRaising
 15	Lysandre	Lysandre	PROPN	_	_	14	obj	_	_
 16	si	si	SCONJ	_	_	19	mark	_	_
 17	elle	lui	PRON	_	Emph=No|Gender=Fem|Number=Sing|Person=3|PronType=Prs	19	nsubj	_	_
 18	le	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	obj	_	_
-19	souhaite	souhaiter	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	advcl	_	SpaceAfter=No
+19	souhaite	souhaiter	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	advcl	_	CxnElt=14:Conditional-NeutralEpistemic.Protasis@f|SpaceAfter=No
 20	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = fr-ud-dev_01048
@@ -30940,9 +30939,9 @@
 12	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	expl:subj	_	_
 13	devrait	devoir	VERB	_	Mood=Cnd|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	conj	_	_
 14	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	15	expl:comp	_	_
-15	avoir	avoir	VERB	_	VerbForm=Inf	13	xcomp	_	Subject=SubjRaising
+15	avoir	avoir	VERB	_	VerbForm=Inf	13	xcomp	_	Cxn=Existential-HavePred-ItExpl-ThereExpl|Subject=SubjRaising
 16	d'	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	17	det	_	SpaceAfter=No
-17	amibes	amibe	NOUN	_	Gender=Fem|Number=Plur	15	obj	_	_
+17	amibes	amibe	NOUN	_	Gender=Fem|Number=Plur	15	obj	_	CxnElt=15:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 18	prêtes	prêt	ADJ	_	Gender=Fem|Number=Plur	17	amod	_	_
 19	à	à	ADP	_	_	21	mark	_	_
 20	se	soi	PRON	_	Emph=No|Person=3|PronType=Prs|Reflex=Yes	21	obj	_	_
@@ -31613,10 +31612,10 @@
 15	,	,	PUNCT	_	_	16	punct	_	_
 16	auteur	auteur	NOUN	_	Gender=Masc|Number=Sing	10	conj	_	_
 17	de	de	ADP	_	_	18	case	_	_
-18	Pétain	Pétain	PROPN	_	_	16	nmod	_	_
+18	Pétain	Pétain	PROPN	_	_	16	nmod	_	Cxn=Interrogative-Alternative|CxnElt=18:Interrogative-Alternative.Choice1,18:Interrogative-Alternative.Clause
 19	ou	ou	CCONJ	_	_	21	cc	_	_
 20	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
-21	démocratie	démocratie	NOUN	_	Gender=Fem|Number=Sing	18	conj	_	_
+21	démocratie	démocratie	NOUN	_	Gender=Fem|Number=Sing	18	conj	_	CxnElt=18:Interrogative-Alternative.Choice2
 22	?	?	PUNCT	_	_	18	punct	_	_
 
 # sent_id = fr-ud-dev_01140
@@ -32432,10 +32431,10 @@
 
 # sent_id = fr-ud-dev_01175
 # text = Pourquoi pas un tournage dans notre capitale puisque dans le dernier épisode Andy, Silas et Shane ont pris l'avion pour Paris.
-1	Pourquoi	pourquoi	ADV	_	PronType=Int	4	advmod	_	wordform=pourquoi
+1	Pourquoi	pourquoi	ADV	_	PronType=Int	4	advmod	_	CxnElt=4:Interrogative-WHInfo-Indirect.WHWord|wordform=pourquoi
 2	pas	pas	ADV	_	Polarity=Neg	4	advmod	_	_
 3	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	tournage	tournage	NOUN	_	Gender=Masc|Number=Sing	0	root	_	_
+4	tournage	tournage	NOUN	_	Gender=Masc|Number=Sing	0	root	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=4:Interrogative-WHInfo-Indirect.Clause
 5	dans	dans	ADP	_	_	7	case	_	_
 6	notre	son	DET	_	Number=Sing|Number[psor]=Plur|Person[psor]=1|Poss=Yes|PronType=Prs	7	det	_	_
 7	capitale	capitale	NOUN	_	Gender=Fem|Number=Sing	4	nmod	_	_
@@ -33224,7 +33223,7 @@
 6	de	de	ADP	_	_	8	case	_	_
 7	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
 8	rubans	ruban	NOUN	_	Gender=Masc|Number=Plur	2	nmod	_	_
-9	empêche	empêcher	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+9	empêche	empêcher	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=9:Conditional-NeutralEpistemic.Apodosis@p
 10	tout	tout	DET	_	Gender=Masc|Number=Sing|PronType=Ind	11	det	_	_
 11	mouvement	mouvement	NOUN	_	Gender=Masc|Number=Sing	9	obj	_	_
 12	s'	si	SCONJ	_	_	17	mark	_	SpaceAfter=No
@@ -33232,7 +33231,7 @@
 14	n'	ne	ADV	_	Polarity=Neg	17	advmod	_	SpaceAfter=No
 15	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
 16	pas	pas	ADV	_	Polarity=Neg	17	advmod	_	_
-17	validé	valider	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	9	advcl	_	_
+17	validé	valider	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	9	advcl	_	CxnElt=9:Conditional-NeutralEpistemic.Protasis@f
 18	par	par	ADP	_	_	20	case	_	_
 19	l'	le	DET	_	Definite=Def|Number=Sing|PronType=Art	20	det	_	SpaceAfter=No
 20	ensemble	ensemble	NOUN	_	Gender=Masc|Number=Sing	17	obl:agent	_	_
@@ -33412,7 +33411,7 @@
 7	élections	élection	NOUN	_	Gender=Fem|Number=Plur	3	nmod	_	_
 8	à	à	ADP	_	_	9	case	_	_
 9	Mirabeau	Mirabeau	PROPN	_	_	10	obl:mod	_	_
-10	donnent	donner	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	advcl	_	_
+10	donnent	donner	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	advcl	_	CxnElt=26:Conditional-NeutralEpistemic.Protasis@f
 11	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	12	det	_	_
 12	résultats	résultat	NOUN	_	Gender=Masc|Number=Plur	10	obj	_	_
 13	équivalents	équivalent	ADJ	_	Gender=Masc|Number=Plur	12	amod	_	_
@@ -33429,7 +33428,7 @@
 23	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux:pass	_	_
 24	toujours	toujours	ADV	_	_	26	advmod	_	_
 25	plus	plus	ADV	_	_	26	advmod	_	_
-26	élevée	élever	VERB	_	Gender=Fem|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	_
+26	élevée	élever	VERB	_	Gender=Fem|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=26:Conditional-NeutralEpistemic.Apodosis@p
 27	(	(	PUNCT	_	_	31	punct	_	SpaceAfter=No
 28	jusqu'	jusque	ADP	_	_	31	case	_	SpaceAfter=No
 29	à	à	ADP	_	_	31	case	_	_
@@ -33520,7 +33519,7 @@
 2	renouveau	renouveau	NOUN	_	Gender=Masc|Number=Sing	5	nsubj	_	_
 3	désiré	désirer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	2	acl	_	_
 4	se	soi	PRON	_	Person=3|PronType=Prs|Reflex=Yes	5	expl:pv	_	_
-5	produira	produire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	SpaceAfter=No
+5	produira	produire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 6	-t-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	expl:subj	_	wordform=il
 7	?	?	PUNCT	_	_	5	punct	_	_
 
@@ -33542,7 +33541,7 @@
 13	belle	beau	ADJ	_	Gender=Fem|Number=Sing	16	amod	_	_
 14	et	et	CCONJ	_	_	15	cc	_	_
 15	plausible	plausible	ADJ	_	Gender=Fem|Number=Sing	13	conj	_	_
-16	reconstitution	reconstitution	NOUN	_	Gender=Fem|Number=Sing	6	acl:relcl	_	SpaceAfter=No
+16	reconstitution	reconstitution	NOUN	_	Gender=Fem|Number=Sing	6	acl:relcl	_	Cxn=Conditional-NeutralEpistemic|CxnElt=16:Conditional-NeutralEpistemic.Apodosis@p|SpaceAfter=No
 17	,	,	PUNCT	_	_	26	punct	_	_
 18	si	si	SCONJ	_	ExtPos=ADP	26	mark	_	Idiom=Yes
 19	ce	ce	PRON	_	Gender=Masc|Person=3|PronType=Dem	18	fixed	_	InIdiom=Yes
@@ -33552,7 +33551,7 @@
 23	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	nsubj:pass	_	_
 24	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux:tense	_	_
 25	été	être	AUX	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part	26	aux:pass	_	_
-26	dessiné	dessiner	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	16	advcl	_	_
+26	dessiné	dessiner	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	16	advcl	_	CxnElt=16:Conditional-NeutralEpistemic.Protasis@f
 27	inversé	inverser	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	26	xcomp	_	Subject=SubjRaising
 28	(	(	PUNCT	_	_	29	punct	_	SpaceAfter=No
 29	gauche	gauche	NOUN	_	Gender=Fem|Number=Sing	27	obl:mod	_	SpaceAfter=No
@@ -33849,7 +33848,7 @@
 32	certains	certain	DET	_	Gender=Masc|Number=Plur|PronType=Ind	33	det	_	_
 33	moments	moment	NOUN	_	Gender=Masc|Number=Plur	34	obl:mod	_	_
 34	peut	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	acl:relcl	_	_
-35	nuire	nuire	VERB	_	VerbForm=Inf	34	xcomp	_	Subject=SubjRaising
+35	nuire	nuire	VERB	_	VerbForm=Inf	34	xcomp	_	Cxn=Conditional-NeutralEpistemic|CxnElt=35:Conditional-NeutralEpistemic.Apodosis@p|Subject=SubjRaising
 36	à	à	ADP	_	_	38	case	_	_
 37	sa	son	DET	_	Gender=Fem|Number=Sing|Number[psor]=Sing|Person[psor]=3|Poss=Yes|PronType=Prs	38	det	_	_
 38	régularité	régularité	NOUN	_	Gender=Fem|Number=Sing	35	obl:arg	_	_
@@ -33861,7 +33860,7 @@
 43	par	par	ADP	_	ExtPos=ADV	46	advmod	_	Idiom=Yes
 44	exemple	exemple	NOUN	_	Gender=Masc|Number=Sing	43	fixed	_	InIdiom=Yes
 45	elle	lui	PRON	_	Emph=No|Gender=Fem|Number=Sing|Person=3|PronType=Prs	46	nsubj	_	_
-46	manque	manquer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	35	advcl	_	_
+46	manque	manquer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	35	advcl	_	CxnElt=35:Conditional-NeutralEpistemic.Protasis@f
 47	de	de	ADP	_	_	48	case	_	_
 48	confiance	confiance	NOUN	_	Gender=Fem|Number=Sing	46	obl:arg	_	SpaceAfter=No
 49	.	.	PUNCT	_	_	16	punct	_	_
@@ -34266,9 +34265,9 @@
 5	été	être	AUX	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part	6	aux:pass	_	_
 6	mobilisés	mobiliser	VERB	_	Gender=Masc|Number=Plur|Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	_
 7	pour	pour	ADP	_	_	8	mark	_	_
-8	aider	aider	VERB	_	VerbForm=Inf	6	advcl	_	Subject=SubjRaising
+8	aider	aider	VERB	_	VerbForm=Inf	6	advcl	_	Cxn=Conditional-NeutralEpistemic,Conditional-Reduced|CxnElt=8:Conditional-NeutralEpistemic.Apodosis@p,8:Conditional-Reduced.Apodosis@p|Subject=SubjRaising
 9	si	si	SCONJ	_	_	10	mark	_	_
-10	nécessaire	nécessaire	ADJ	_	Gender=Masc|Number=Sing	8	advcl	_	_
+10	nécessaire	nécessaire	ADJ	_	Gender=Masc|Number=Sing	8	advcl	_	CxnElt=8:Conditional-NeutralEpistemic.Protasis@f,8:Conditional-Reduced.Protasis@f
 11	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	12	det	_	_
 12	habitants	habitant	NOUN	_	Gender=Masc|Number=Plur	8	obj	_	_
 13	après	après	ADP	_	_	15	case	_	_
@@ -34817,7 +34816,7 @@
 # text = Dieu nous punit ?
 1	Dieu	Dieu	PROPN	_	_	3	nsubj	_	_
 2	nous	nous	PRON	_	Emph=No|Number=Plur|Person=1|PronType=Prs	3	obj	_	_
-3	punit	punir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	punit	punir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = fr-ud-dev_01257
@@ -35003,7 +35002,7 @@
 2	payement	payement	NOUN	_	Gender=Masc|Number=Sing	3	nsubj	_	_
 3	peut	pouvoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	éventuellement	éventuellement	ADV	_	_	3	advmod	_	_
-5	passer	passer	VERB	_	VerbForm=Inf	3	xcomp	_	Subject=SubjRaising
+5	passer	passer	VERB	_	VerbForm=Inf	3	xcomp	_	Cxn=Conditional-NeutralEpistemic|CxnElt=5:Conditional-NeutralEpistemic.Apodosis@p|Subject=SubjRaising
 6	par	par	ADP	_	_	8	case	_	_
 7	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
 8	tiers	tiers	NOUN	_	Gender=Masc|Number=Sing	5	obl:arg	_	_
@@ -35015,7 +35014,7 @@
 14	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 15	cure	cure	NOUN	_	Gender=Fem|Number=Sing	17	nsubj:pass	_	_
 16	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
-17	menée	mener	VERB	_	Gender=Fem|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	5	advcl	_	_
+17	menée	mener	VERB	_	Gender=Fem|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	5	advcl	_	CxnElt=5:Conditional-NeutralEpistemic.Protasis@f
 18	par	par	ADP	_	_	20	case	_	_
 19	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
 20	médecin	médecin	NOUN	_	Gender=Masc|Number=Sing	17	obl:agent	_	SpaceAfter=No
@@ -37248,8 +37247,8 @@
 5	:	:	PUNCT	_	_	9	punct	_	_
 6	«	«	PUNCT	_	_	9	punct	_	_
 7	Mais	mais	CCONJ	_	_	9	cc	_	wordform=mais
-8	quelle	quel	DET	_	Gender=Fem|Number=Sing|PronType=Int	9	det	_	_
-9	importance	importance	NOUN	_	Gender=Fem|Number=Sing	4	parataxis	_	_
+8	quelle	quel	DET	_	Gender=Fem|Number=Sing|PronType=Int	9	det	_	CxnElt=9:Interrogative-WHInfo-Direct.WHWord
+9	importance	importance	NOUN	_	Gender=Fem|Number=Sing	4	parataxis	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=9:Interrogative-WHInfo-Direct.Clause
 10	que	que	SCONJ	_	_	13	mark	_	_
 11	ce	ce	PRON	_	Gender=Masc|Person=3|PronType=Dem	13	nsubj	_	_
 12	soit	être	AUX	_	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	_
@@ -38363,7 +38362,7 @@
 # text = Si vous travaillez dans le quartier et que vous en avez marre de manger à la cantine de l'entreprise, allez vous restaurer aux Jardins d'Epicure.
 1	Si	si	SCONJ	_	_	3	mark	_	wordform=si
 2	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	_
-3	travaillez	travailler	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	_	_
+3	travaillez	travailler	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	_	CxnElt=22:Conditional-NeutralEpistemic.Protasis@f
 4	dans	dans	ADP	_	_	6	case	_	_
 5	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 6	quartier	quartier	NOUN	_	Gender=Masc|Number=Sing	3	obl:mod	_	_
@@ -38382,7 +38381,7 @@
 19	l'	le	DET	_	Definite=Def|Number=Sing|PronType=Art	20	det	_	SpaceAfter=No
 20	entreprise	entreprise	NOUN	_	Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
 21	,	,	PUNCT	_	_	3	punct	_	_
-22	allez	aller	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
+22	allez	aller	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=22:Conditional-NeutralEpistemic.Apodosis@p
 23	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	24	obj	_	_
 24	restaurer	restaurer	VERB	_	VerbForm=Inf	22	xcomp	_	Subject=SubjRaising
 25-26	aux	_	_	_	_	_	_	_	_
@@ -39317,10 +39316,10 @@
 
 # sent_id = fr-ud-dev_01413
 # text = Qui donc a écrit que les « rescapés des camps hitlériens étaient des revenants, dans le sens du mot "spectres" » ?
-1	Qui	qui	PRON	_	PronType=Int	4	nsubj	_	wordform=qui
+1	Qui	qui	PRON	_	PronType=Int	4	nsubj	_	CxnElt=4:Interrogative-WHInfo-Direct.WHWord|wordform=qui
 2	donc	donc	ADV	_	_	4	advmod	_	_
 3	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux:tense	_	_
-4	écrit	écrire	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	_
+4	écrit	écrire	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	que	que	SCONJ	_	_	15	mark	_	_
 6	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
 7	«	«	PUNCT	_	_	8	punct	_	_

--- a/fr_gsd-ud-test.conllu
+++ b/fr_gsd-ud-test.conllu
@@ -1,4 +1,3 @@
-# global.columns = ID FORM LEMMA UPOS XPOS FEATS HEAD DEPREL DEPS MISC
 # sent_id = fr-ud-test_00001
 # text = Je sens qu'entre ça et les films de médecins et scientifiques fous que nous avons déjà vus, nous pourrions emprunter un autre chemin pour l'origine.
 1	Je	moi	PRON	_	Emph=No|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	wordform=je
@@ -365,7 +364,7 @@
 1	Est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No|wordform=est
 2	-ce	ce	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	4	expl:subj	_	wordform=ce
 3	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	fait	fait	NOUN	_	Gender=Masc|Number=Sing	0	root	_	_
+4	fait	fait	NOUN	_	Gender=Masc|Number=Sing	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5-6	du	_	_	_	_	_	_	_	_
 5	de	de	ADP	_	_	7	case	_	_
 6	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
@@ -514,7 +513,7 @@
 4	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 5	Maroc	Maroc	PROPN	_	Gender=Masc|Number=Sing	7	nsubj	_	_
 6	n'	ne	ADV	_	Polarity=Neg	7	advmod	_	SpaceAfter=No
-7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	advcl	_	_
+7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	advcl	_	CxnElt=22:Conditional-NeutralEpistemic.Protasis@f
 8	pas	pas	ADV	_	Polarity=Neg	7	advmod	_	_
 9	de	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	10	det	_	_
 10	relations	relation	NOUN	_	Gender=Fem|Number=Plur	7	obj	_	_
@@ -529,7 +528,7 @@
 19	n'	ne	ADV	_	Polarity=Neg	22	advmod	_	SpaceAfter=No
 20	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux:tense	_	_
 21	jamais	jamais	ADV	_	Polarity=Neg	22	advmod	_	_
-22	empêché	empêcher	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	_
+22	empêché	empêcher	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=22:Conditional-NeutralEpistemic.Apodosis@p
 23	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	24	det	_	_
 24	ministres	ministre	NOUN	_	Gender=Masc|Number=Plur	22	obj	_	_
 25	de	de	ADP	_	_	27	mark	_	_
@@ -929,7 +928,7 @@
 3	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	SpaceAfter=No
 4	-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	expl:subj	_	wordform=il
 5	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Poussière	poussière	NOUN	_	Gender=Fem|Number=Sing	0	root	_	wordform=poussière
+6	Poussière	poussière	NOUN	_	Gender=Fem|Number=Sing	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause|wordform=poussière
 7	?	?	PUNCT	_	_	6	punct	_	_
 
 # sent_id = fr-ud-test_00036
@@ -971,11 +970,11 @@
 
 # sent_id = fr-ud-test_00038
 # text = Combien de fois ne célébrons-nous que nous-mêmes, et ne prenons-nous même pas conscience de sa présence ?
-1	Combien	combien	ADV	_	ExtPos=PRON|PronType=Int	5	obl:mod	_	wordform=combien
+1	Combien	combien	ADV	_	ExtPos=PRON|PronType=Int	5	obl:mod	_	CxnElt=5:Interrogative-WHInfo-Direct.WHWord|wordform=combien
 2	de	de	ADP	_	_	3	case	_	_
 3	fois	fois	NOUN	_	Gender=Fem|Number=Plur	1	obl:arg	_	_
 4	ne	ne	ADV	_	Polarity=Neg	5	advmod	_	_
-5	célébrons	célébrer	VERB	_	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+5	célébrons	célébrer	VERB	_	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 6	-nous	nous	PRON	_	Emph=No|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	wordform=nous
 7	que	que	ADV	_	Polarity=Neg	8	advmod	_	_
 8	nous-mêmes	nous-mêmes	PRON	_	Emph=Yes|Number=Plur|Person=1|PronType=Prs|Reflex=Yes	5	obj	_	SpaceAfter=No
@@ -1188,10 +1187,10 @@
 # sent_id = fr-ud-test_00047
 # text = Y a-t-il un risque de voir les choses tourner mal en Syrie ?
 1	Y	y	PRON	_	Emph=No|Person=3|PronType=Prs	2	expl:comp	_	wordform=y
-2	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+2	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl,Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 3	-t-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	expl:subj	_	wordform=il
 4	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	risque	risque	NOUN	_	Gender=Masc|Number=Sing	2	obj	_	_
+5	risque	risque	NOUN	_	Gender=Masc|Number=Sing	2	obj	_	CxnElt=2:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 6	de	de	ADP	_	_	7	mark	_	_
 7	voir	voir	VERB	_	VerbForm=Inf	5	acl	_	Subject=Generic
 8	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
@@ -1327,14 +1326,14 @@
 
 # sent_id = fr-ud-test_00052
 # text = Arrêtez la lecture, si cela vous suffit pour aujourd'hui.
-1	Arrêtez	arrêter	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	wordform=arrêtez
+1	Arrêtez	arrêter	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=1:Conditional-NeutralEpistemic.Apodosis@p|wordform=arrêtez
 2	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
 3	lecture	lecture	NOUN	_	Gender=Fem|Number=Sing	1	obj	_	SpaceAfter=No
 4	,	,	PUNCT	_	_	8	punct	_	_
 5	si	si	SCONJ	_	_	8	mark	_	_
 6	cela	cela	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	8	nsubj	_	_
 7	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	8	iobj	_	_
-8	suffit	suffire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	advcl	_	_
+8	suffit	suffire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	advcl	_	CxnElt=1:Conditional-NeutralEpistemic.Protasis@f
 9	pour	pour	ADP	_	_	10	case	_	_
 10	aujourd'hui	aujourd'hui	ADV	_	_	8	advmod	_	SpaceAfter=No
 11	.	.	PUNCT	_	_	1	punct	_	_
@@ -1528,7 +1527,7 @@
 22	étaient	être	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Imp|VerbForm=Fin	25	aux:tense	_	SpaceAfter=No
 23	-ils	eux	PRON	_	Emph=No|Gender=Masc|Number=Plur|Person=3|PronType=Prs	25	expl:subj	_	wordform=il
 24	fait	faire	AUX	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part	25	aux:pass	_	_
-25	arrêter	arrêter	VERB	_	VerbForm=Inf	0	root	_	Subject=Generic
+25	arrêter	arrêter	VERB	_	VerbForm=Inf	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=25:Interrogative-Polar-Direct.Clause|Subject=Generic
 26	mercredi	mercredi	NOUN	_	Gender=Masc|Number=Sing	25	obl:mod	_	_
 27	dernier	dernier	ADJ	_	Gender=Masc|Number=Sing	26	amod	_	_
 28	à	à	ADP	_	_	30	case	_	_
@@ -1608,9 +1607,9 @@
 
 # sent_id = fr-ud-test_00061
 # text = Qui a donné l'exemple ?
-1	Qui	qui	PRON	_	PronType=Int	3	nsubj	_	wordform=qui
+1	Qui	qui	PRON	_	PronType=Int	3	nsubj	_	CxnElt=3:Interrogative-WHInfo-Direct.WHWord|wordform=qui
 2	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux:tense	_	_
-3	donné	donner	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	_
+3	donné	donner	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	l'	le	DET	_	Definite=Def|Number=Sing|PronType=Art	5	det	_	SpaceAfter=No
 5	exemple	exemple	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	_
 6	?	?	PUNCT	_	_	3	punct	_	_
@@ -1637,7 +1636,7 @@
 18	active	actif	ADJ	_	Gender=Fem|Number=Sing	17	amod	_	_
 19	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux:pass	_	_
 20	bien	bien	ADV	_	_	21	advmod	_	_
-21	exonéré	exonérer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	39	advcl	_	_
+21	exonéré	exonérer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	39	advcl	_	CxnElt=39:Conditional-NeutralEpistemic.Protasis@f
 22	d'	de	ADP	_	_	23	case	_	SpaceAfter=No
 23	impôt	impôt	NOUN	_	Gender=Masc|Number=Sing	21	obl:arg	_	_
 24	sur	sur	ADP	_	_	26	case	_	_
@@ -1656,7 +1655,7 @@
 36	complément	complément	NOUN	_	Gender=Masc|Number=Sing	33	nmod	_	_
 37	d'	de	ADP	_	_	38	case	_	SpaceAfter=No
 38	activité	activité	NOUN	_	Gender=Fem|Number=Sing	36	nmod	_	_
-39	doit	devoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	_	_
+39	doit	devoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	_	Cxn=Conditional-NeutralEpistemic|CxnElt=39:Conditional-NeutralEpistemic.Apodosis@p
 40	être	être	AUX	_	VerbForm=Inf	41	aux:pass	_	Subject=SubjRaising
 41	déduit	déduire	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Pass	39	xcomp	_	_
 42	de	de	ADP	_	_	44	case	_	_
@@ -1706,13 +1705,13 @@
 32	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
 33	situation	situation	NOUN	_	Gender=Fem|Number=Sing	35	nsubj	_	_
 34	ne	ne	ADV	_	Polarity=Neg	35	advmod	_	_
-35	dégénère	dégénérer	VERB	_	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	ccomp	_	_
+35	dégénère	dégénérer	VERB	_	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	ccomp	_	Cxn=Conditional-NeutralEpistemic|CxnElt=35:Conditional-NeutralEpistemic.Apodosis@p
 36	si	si	SCONJ	_	_	41	mark	_	_
 37	l'	le	DET	_	Definite=Def|Number=Sing|PronType=Art	38	det	_	SpaceAfter=No
 38	aide	aide	NOUN	_	Gender=Fem|Number=Sing	41	nsubj	_	_
 39	internationale	international	ADJ	_	Gender=Fem|Number=Sing	38	amod	_	_
 40	ne	ne	ADV	_	Polarity=Neg	41	advmod	_	_
-41	pointe	pointer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	35	advcl	_	_
+41	pointe	pointer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	35	advcl	_	CxnElt=35:Conditional-NeutralEpistemic.Protasis@f
 42	pas	pas	ADV	_	Polarity=Neg	41	advmod	_	_
 43	plus	plus	ADV	_	_	44	advmod	_	_
 44	vite	vite	ADV	_	_	41	advmod	_	_
@@ -2052,8 +2051,8 @@
 
 # sent_id = fr-ud-test_00073
 # text = Que dit l'Eglise sur ce point délicat ?
-1	Que	que	PRON	_	PronType=Int	2	obj	_	wordform=que
-2	dit	dire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+1	Que	que	PRON	_	PronType=Int	2	obj	_	CxnElt=2:Interrogative-WHInfo-Direct.WHWord|wordform=que
+2	dit	dire	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	l'	le	DET	_	Definite=Def|Number=Sing|PronType=Art	4	det	_	SpaceAfter=No
 4	Eglise	église	NOUN	_	Gender=Fem|Number=Sing	2	nsubj	_	wordform=église
 5	sur	sur	ADP	_	_	7	case	_	_
@@ -2256,13 +2255,13 @@
 # text = Je me demande s'il y a une loi chez nous qui peut condamner des citoyens pour des rêves illégaux ?
 1	Je	moi	PRON	_	Emph=No|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	wordform=je
 2	me	soi	PRON	_	Number=Sing|Person=1|PronType=Prs|Reflex=Yes	3	expl:pv	_	_
-3	demande	demander	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	demande	demander	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	s'	si	SCONJ	_	_	7	mark	_	SpaceAfter=No
 5	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	expl:subj	_	_
 6	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	7	expl:comp	_	_
-7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
+7	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 8	une	un	DET	_	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	loi	loi	NOUN	_	Gender=Fem|Number=Sing	7	obj	_	_
+9	loi	loi	NOUN	_	Gender=Fem|Number=Sing	7	obj	_	CxnElt=7:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 10	chez	chez	ADP	_	_	11	case	_	_
 11	nous	nous	PRON	_	Emph=Yes|Number=Plur|Person=1|PronType=Prs	7	obl:mod	_	_
 12	qui	qui	PRON	_	PronType=Rel	13	nsubj	_	_
@@ -2844,11 +2843,11 @@
 # text = Jusqu'à quand la France officielle maintiendra-t-elle sa préférence pour la protection des agresseurs des droits de l'homme ?
 1	Jusqu'	jusque	ADP	_	_	3	case	_	SpaceAfter=No|wordform=jusqu'
 2	à	à	ADP	_	_	3	case	_	_
-3	quand	quand	ADV	_	PronType=Int	7	advmod	_	_
+3	quand	quand	ADV	_	PronType=Int	7	advmod	_	CxnElt=7:Interrogative-WHInfo-Direct.WHWord
 4	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	France	France	PROPN	_	Gender=Fem|Number=Sing	7	nsubj	_	_
 6	officielle	officiel	ADJ	_	Gender=Fem|Number=Sing	5	amod	_	_
-7	maintiendra	maintenir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	SpaceAfter=No
+7	maintiendra	maintenir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=7:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 8	-t-elle	lui	PRON	_	Emph=No|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	expl:subj	_	wordform=elle
 9	sa	son	DET	_	Gender=Fem|Number=Sing|Number[psor]=Sing|Person[psor]=3|Poss=Yes|PronType=Prs	10	det	_	_
 10	préférence	préférence	NOUN	_	Gender=Fem|Number=Sing	7	obj	_	_
@@ -3077,7 +3076,7 @@
 3	si	si	SCONJ	_	_	6	mark	_	_
 4	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	5	det	_	_
 5	supporters	supporter	NOUN	_	Gender=Masc|Number=Plur	6	nsubj	_	_
-6	veulent	vouloir	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	advcl	_	_
+6	veulent	vouloir	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	advcl	_	CxnElt=29:Conditional-NeutralEpistemic.Protasis@f
 7	aider	aider	VERB	_	VerbForm=Inf	6	xcomp	_	Subject=SubjRaising
 8	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
 9	club	club	NOUN	_	Gender=Masc|Number=Sing	7	obj	_	_
@@ -3101,7 +3100,7 @@
 26	nous	nous	PRON	_	Emph=No|Number=Plur|Person=1|PronType=Prs	29	iobj:agent	_	_
 27	le	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	29	obj	_	_
 28	fassent	faire	AUX	_	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	aux:caus	_	_
-29	savoir	savoir	VERB	_	VerbForm=Inf	0	root	_	SpaceAfter=No|Subject=Generic
+29	savoir	savoir	VERB	_	VerbForm=Inf	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=29:Conditional-NeutralEpistemic.Apodosis@p|SpaceAfter=No|Subject=Generic
 30	.	.	PUNCT	_	_	29	punct	_	_
 31	"	"	PUNCT	_	_	29	punct	_	_
 
@@ -3212,7 +3211,7 @@
 33	janvier	janvier	NOUN	_	Gender=Masc|Number=Sing	32	nmod	_	_
 34	2000	2000	NUM	_	Number=Plur	33	nmod	_	_
 35	avaient	avoir	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Imp|VerbForm=Fin	36	aux:tense	_	_
-36	adopté	adopter	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	45	advcl	_	_
+36	adopté	adopter	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	45	advcl	_	CxnElt=45:Conditional-NegativeEpistemic.Protasis@f
 37	une	un	DET	_	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	39	det	_	_
 38	telle	tel	ADJ	_	Gender=Fem|Number=Sing	39	amod	_	_
 39	politique	politique	NOUN	_	Gender=Fem|Number=Sing	36	obj	_	SpaceAfter=No
@@ -3221,7 +3220,7 @@
 42	vies	vie	NOUN	_	Gender=Fem|Number=Plur	45	nsubj:pass	_	_
 43	auraient	avoir	AUX	_	Mood=Cnd|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	45	aux:tense	_	_
 44	été	être	AUX	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part	45	aux:pass	_	_
-45	sauvées	sauver	VERB	_	Gender=Fem|Number=Plur|Tense=Past|VerbForm=Part|Voice=Pass	13	acl	_	SpaceAfter=No
+45	sauvées	sauver	VERB	_	Gender=Fem|Number=Plur|Tense=Past|VerbForm=Part|Voice=Pass	13	acl	_	Cxn=Conditional-NegativeEpistemic|CxnElt=45:Conditional-NegativeEpistemic.Apodosis@p|SpaceAfter=No
 46	.	.	PUNCT	_	_	10	punct	_	_
 
 # sent_id = fr-ud-test_00108
@@ -3715,13 +3714,13 @@
 46	Affaire	affaire	NOUN	_	ExtPos=PROPN|Gender=Fem|Number=Sing	40	appos	_	Title=Yes|wordform=affaire
 47	DSK	DSK	PROPN	_	_	46	appos	_	InTitle=Yes
 48	:	:	PUNCT	_	_	55	punct	_	InTitle=Yes
-49	comment	comment	ADV	_	PronType=Int	55	advmod	_	InTitle=Yes
+49	comment	comment	ADV	_	PronType=Int	55	advmod	_	CxnElt=55:Interrogative-WHInfo-Indirect.WHWord|InTitle=Yes
 50	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	51	det	_	InTitle=Yes
 51	position	position	NOUN	_	Gender=Fem|Number=Sing	55	nsubj	_	InTitle=Yes
 52	d'	de	ADP	_	_	53	case	_	InTitle=Yes|SpaceAfter=No
 53	Aubry	Aubry	PROPN	_	_	51	nmod	_	InTitle=Yes
 54	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	55	aux:tense	_	InTitle=Yes
-55	évolué	évoluer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	46	appos	_	InTitle=Yes|SpaceAfter=No
+55	évolué	évoluer	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	46	appos	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=55:Interrogative-WHInfo-Indirect.Clause|InTitle=Yes|SpaceAfter=No
 56	"	"	PUNCT	_	_	46	punct	_	SpaceAfter=No
 57	)	)	PUNCT	_	_	38	punct	_	SpaceAfter=No
 58	.	.	PUNCT	_	_	29	punct	_	_
@@ -4122,9 +4121,9 @@
 # text = Il y a un personnage très absent tout au long du roman, le "peuple".
 1	Il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	expl:subj	_	wordform=il
 2	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	3	expl:comp	_	_
-3	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 4	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	personnage	personnage	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	_
+5	personnage	personnage	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	CxnElt=3:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 6	très	très	ADV	_	_	7	advmod	_	_
 7	absent	absent	ADJ	_	Gender=Masc|Number=Sing	5	amod	_	_
 8	tout	tout	ADV	_	_	10	advmod	_	_
@@ -4154,7 +4153,7 @@
 # text = Si Moody's estime que leur note ne devrait pas baisser de plus d'un cran, la situation n'est pas la même pour la Société Générale, dont la dégradation pourrait atteindre deux crans.
 1	Si	si	SCONJ	_	_	3	mark	_	wordform=si
 2	Moody's	Moody's	PROPN	_	_	3	nsubj	_	_
-3	estime	estimer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	advcl	_	_
+3	estime	estimer	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	advcl	_	CxnElt=23:Conditional-NeutralEpistemic.Protasis@f
 4	que	que	SCONJ	_	_	8	mark	_	_
 5	leur	son	DET	_	Number=Sing|Number[psor]=Plur|Person[psor]=3|Poss=Yes|PronType=Prs	6	det	_	_
 6	note	note	NOUN	_	Gender=Fem|Number=Sing	8	nsubj	_	_
@@ -4174,7 +4173,7 @@
 20	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	cop	_	_
 21	pas	pas	ADV	_	Polarity=Neg	23	advmod	_	_
 22	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
-23	même	même	ADJ	_	Gender=Fem|Number=Sing	0	root	_	_
+23	même	même	ADJ	_	Gender=Fem|Number=Sing	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=23:Conditional-NeutralEpistemic.Apodosis@p
 24	pour	pour	ADP	_	_	26	case	_	_
 25	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
 26	Société	société	NOUN	_	Gender=Fem|Number=Sing	23	obl:mod	_	wordform=société
@@ -4377,7 +4376,7 @@
 
 # sent_id = fr-ud-test_00145
 # text = Qu'est-ce que 1.000 emplois quand on en détruit et qu'on en créé 20.000 tous les jours en France ?
-1	Qu'	que	PRON	_	PronType=Int	0	root	_	SpaceAfter=No|wordform=qu'
+1	Qu'	que	PRON	_	PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No|wordform=qu'
 2	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	SpaceAfter=No
 3	-ce	ce	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	1	nsubj	_	wordform=ce
 4	que	que	SCONJ	_	_	6	case	_	_
@@ -4475,15 +4474,15 @@
 2	,	,	PUNCT	_	_	1	punct	_	_
 3	on	on	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Ind	4	nsubj	_	_
 4	saura	savoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
-5	qui	qui	PRON	_	PronType=Int	8	nsubj	_	_
+5	qui	qui	PRON	_	PronType=Int	8	nsubj	_	CxnElt=8:Interrogative-WHInfo-Indirect.WHWord
 6	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
 7	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	coupable	coupable	NOUN	_	Gender=Masc|Number=Sing	4	ccomp	_	_
+8	coupable	coupable	NOUN	_	Gender=Masc|Number=Sing	4	ccomp	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=8:Interrogative-WHInfo-Indirect.Clause
 9	et	et	CCONJ	_	_	13	cc	_	_
-10	qui	qui	PRON	_	PronType=Int	13	nsubj	_	_
+10	qui	qui	PRON	_	PronType=Int	13	nsubj	_	CxnElt=13:Interrogative-WHInfo-Indirect.WHWord
 11	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	_
 12	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-13	victime	victime	NOUN	_	Gender=Fem|Number=Sing	8	conj	_	_
+13	victime	victime	NOUN	_	Gender=Fem|Number=Sing	8	conj	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=13:Interrogative-WHInfo-Indirect.Clause
 14	»	»	PUNCT	_	_	4	punct	_	SpaceAfter=No
 15	,	,	PUNCT	_	_	17	punct	_	_
 16	a	avoir	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:tense	_	_
@@ -4497,8 +4496,8 @@
 
 # sent_id = fr-ud-test_00150
 # text = Comment repoussez vous les bateaux d'immigrés dans les eaux internationales ?
-1	Comment	comment	ADV	_	PronType=Int	2	advmod	_	wordform=comment
-2	repoussez	repousser	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
+1	Comment	comment	ADV	_	PronType=Int	2	advmod	_	CxnElt=2:Interrogative-WHInfo-Direct.WHWord|wordform=comment
+2	repoussez	repousser	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	2	nsubj	_	_
 4	les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
 5	bateaux	bateau	NOUN	_	Gender=Masc|Number=Plur	2	obj	_	_
@@ -4871,7 +4870,7 @@
 
 # sent_id = fr-ud-test_00161
 # text = Faut-il éviter de se rendre dans les pays du sous-continent indien ?
-1	Faut	falloir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No|wordform=faut
+1	Faut	falloir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause|SpaceAfter=No|wordform=faut
 2	-il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	1	expl:subj	_	wordform=il
 3	éviter	éviter	VERB	_	VerbForm=Inf	1	ccomp	_	Subject=Generic
 4	de	de	ADP	_	_	6	mark	_	_
@@ -5355,7 +5354,7 @@
 
 # sent_id = fr-ud-test_00178
 # text = Quel est le coût d'un tel projet ?
-1	Quel	quel	ADJ	_	Gender=Masc|Number=Sing|PronType=Int	0	root	_	wordform=quel
+1	Quel	quel	ADJ	_	Gender=Masc|Number=Sing|PronType=Int	0	root	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|wordform=quel
 2	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	_
 3	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
 4	coût	coût	NOUN	_	Gender=Masc|Number=Sing	1	nsubj	_	_
@@ -5610,11 +5609,11 @@
 43	"	"	PUNCT	_	_	46	punct	_	_
 44	Il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	46	expl:subj	_	wordform=il
 45	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	46	expl:comp	_	_
-46	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	37	ccomp	_	_
+46	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	37	ccomp	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 47	bien	bien	ADV	_	_	46	advmod	_	_
 48	de	de	ADP	_	ExtPos=DET	50	det	_	Idiom=Yes
 49	la	le	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	48	fixed	_	InIdiom=Yes
-50	fumée	fumée	NOUN	_	Gender=Fem|Number=Sing	46	obj	_	SpaceAfter=No
+50	fumée	fumée	NOUN	_	Gender=Fem|Number=Sing	46	obj	_	CxnElt=46:Existential-HavePred-ItExpl-ThereExpl.Pivot@f|SpaceAfter=No
 51	,	,	PUNCT	_	_	56	punct	_	_
 52	mais	mais	CCONJ	_	_	56	cc	_	_
 53	c'	ce	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	56	nsubj	_	SpaceAfter=No
@@ -5809,10 +5808,10 @@
 2	Il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	expl:subj	_	wordform=il
 3	n'	ne	ADV	_	Polarity=Neg	5	advmod	_	SpaceAfter=No
 4	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	5	expl:comp	_	_
-5	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 6	pas	pas	ADV	_	Polarity=Neg	5	advmod	_	_
 7	de	un	DET	_	Definite=Ind|Number=Sing|PronType=Art	8	det	_	_
-8	problème	problème	NOUN	_	Gender=Masc|Number=Sing	5	obj	_	_
+8	problème	problème	NOUN	_	Gender=Masc|Number=Sing	5	obj	_	CxnElt=5:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 9	de	de	ADP	_	_	10	case	_	_
 10	banlieue	banlieue	NOUN	_	Gender=Fem|Number=Sing	8	nmod	_	_
 11	et	et	CCONJ	_	_	17	cc	_	_
@@ -6782,10 +6781,10 @@
 # text = Il y a même un café avec des pingouins !
 1	Il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	expl:subj	_	wordform=il
 2	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	3	expl:comp	_	_
-3	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 4	même	même	ADV	_	_	3	advmod	_	_
 5	un	un	DET	_	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	café	café	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	_
+6	café	café	NOUN	_	Gender=Masc|Number=Sing	3	obj	_	CxnElt=3:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 7	avec	avec	ADP	_	_	9	case	_	_
 8	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	9	det	_	_
 9	pingouins	pingouin	NOUN	_	Gender=Masc|Number=Plur	6	nmod	_	_
@@ -7522,8 +7521,8 @@
 4	si	si	SCONJ	_	_	7	mark	_	_
 5	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	7	nsubj	_	_
 6	êtes	être	AUX	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	7	cop	_	_
-7	nombreux	nombreux	ADJ	_	Gender=Masc|Number=Plur	8	advcl	_	_
-8	passez	passer	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	nombreux	nombreux	ADJ	_	Gender=Masc|Number=Plur	8	advcl	_	CxnElt=8:Conditional-NeutralEpistemic.Protasis@f
+8	passez	passer	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=8:Conditional-NeutralEpistemic.Apodosis@p
 9	votre	son	DET	_	Number=Sing|Number[psor]=Plur|Person[psor]=2|Poss=Yes|PronType=Prs	10	det	_	_
 10	chemin	chemin	NOUN	_	Gender=Masc|Number=Sing	8	obj	_	_
 11	c'	ce	PRON	_	Gender=Masc|Number=Sing|Person=3|PronType=Dem	14	nsubj	_	SpaceAfter=No
@@ -7739,8 +7738,8 @@
 
 # sent_id = fr-ud-test_00281
 # text = Que rechercher de plus lorsqu'on a paisiblement séjourné dans une chambre aussi confortable et bien décorée... !
-1	Que	que	PRON	_	PronType=Int	2	obj	_	wordform=que
-2	rechercher	rechercher	VERB	_	VerbForm=Inf	0	root	_	Subject=Generic
+1	Que	que	PRON	_	PronType=Int	2	obj	_	CxnElt=2:Interrogative-WHInfo-Indirect.WHWord|wordform=que
+2	rechercher	rechercher	VERB	_	VerbForm=Inf	0	root	_	Cxn=Interrogative-WHInfo-Indirect|CxnElt=2:Interrogative-WHInfo-Indirect.Clause|Subject=Generic
 3	de	de	ADP	_	ExtPos=ADV	2	advmod	_	Idiom=Yes
 4	plus	plus	ADV	_	_	3	fixed	_	InIdiom=Yes
 5	lorsqu'	lorsque	SCONJ	_	_	9	mark	_	SpaceAfter=No
@@ -7792,7 +7791,7 @@
 # text = Si vous avez le malheur d'y déjeuner lorsque les patrons sont absents vous aurez droit au pire du pire.
 1	Si	si	SCONJ	_	_	3	mark	_	wordform=si
 2	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	_
-3	avez	avoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	_	_
+3	avez	avoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	_	CxnElt=15:Conditional-NeutralEpistemic.Protasis@f
 4	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 5	malheur	malheur	NOUN	_	Gender=Masc|Number=Sing	3	obj:lvc	_	_
 6	d'	de	ADP	_	_	8	mark	_	SpaceAfter=No
@@ -7804,7 +7803,7 @@
 12	sont	être	AUX	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	_
 13	absents	absent	ADJ	_	Gender=Masc|Number=Plur	8	advcl	_	_
 14	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	15	nsubj	_	_
-15	aurez	avoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Fut|VerbForm=Fin	0	root	_	_
+15	aurez	avoir	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Fut|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=15:Conditional-NeutralEpistemic.Apodosis@p
 16	droit	droit	NOUN	_	Gender=Masc|Number=Sing	15	obj:lvc	_	_
 17-18	au	_	_	_	_	_	_	_	_
 17	à	à	ADP	_	_	19	case	_	_
@@ -7820,14 +7819,14 @@
 # text = Si vous souhaitez régaler "vos papilles" n'hésitez surtout pas !
 1	Si	si	SCONJ	_	_	3	mark	_	wordform=si
 2	vous	vous	PRON	_	Emph=No|Number=Plur|Person=2|PronType=Prs	3	nsubj	_	_
-3	souhaitez	souhaiter	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	10	advcl	_	_
+3	souhaitez	souhaiter	VERB	_	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	10	advcl	_	CxnElt=10:Conditional-NeutralEpistemic.Protasis@f
 4	régaler	régaler	VERB	_	VerbForm=Inf	3	xcomp	_	Subject=SubjRaising
 5	"	"	PUNCT	_	_	7	punct	_	SpaceAfter=No
 6	vos	son	DET	_	Number=Plur|Number[psor]=Plur|Person[psor]=2|Poss=Yes|PronType=Prs	7	det	_	_
 7	papilles	papille	NOUN	_	Gender=Fem|Number=Plur	4	obj	_	SpaceAfter=No
 8	"	"	PUNCT	_	_	7	punct	_	_
 9	n'	ne	ADV	_	Polarity=Neg	10	advmod	_	SpaceAfter=No
-10	hésitez	hésiter	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
+10	hésitez	hésiter	VERB	_	Mood=Imp|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=10:Conditional-NeutralEpistemic.Apodosis@p
 11	surtout	surtout	ADV	_	_	12	advmod	_	_
 12	pas	pas	ADV	_	Polarity=Neg	10	advmod	_	_
 13	!	!	PUNCT	_	_	10	punct	_	_
@@ -7874,9 +7873,9 @@
 3	,	,	PUNCT	_	_	2	punct	_	_
 4	il	lui	PRON	_	Emph=No|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	expl:subj	_	_
 5	y	y	PRON	_	Emph=No|Person=3|PronType=Prs	6	expl:comp	_	_
-6	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	_	_
+6	a	avoir	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	_	Cxn=Existential-HavePred-ItExpl-ThereExpl
 7	des	un	DET	_	Definite=Ind|Number=Plur|PronType=Art	8	det	_	_
-8	pizzeria	pizzeria	NOUN	_	Gender=Fem|Number=Sing|Typo=Yes	6	obj	_	CorrectForm=pizzerias|CorrectNumber=Plur
+8	pizzeria	pizzeria	NOUN	_	Gender=Fem|Number=Sing|Typo=Yes	6	obj	_	CorrectForm=pizzerias|CorrectNumber=Plur|CxnElt=6:Existential-HavePred-ItExpl-ThereExpl.Pivot@f
 9	meilleure	meilleur	ADJ	_	Gender=Fem|Number=Sing	8	amod	_	_
 10	et	et	CCONJ	_	_	12	cc	_	_
 11	moins	moins	ADV	_	_	12	advmod	_	_
@@ -8696,7 +8695,7 @@
 17	demandé	demander	VERB	_	Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part|Voice=Act	12	conj	_	_
 18	:	:	PUNCT	_	_	20	punct	_	_
 19	«	«	PUNCT	_	_	20	punct	_	_
-20	qu'	que	PRON	_	PronType=Int	17	ccomp	_	SpaceAfter=No
+20	qu'	que	PRON	_	PronType=Int	17	ccomp	_	Cxn=Interrogative-WHInfo-Direct|CxnElt=20:Interrogative-WHInfo-Direct.Clause,20:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 21	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	cop	_	_
 22	ce	ce	PRON	_	Gender=Masc|Person=3|PronType=Dem	20	expl:subj	_	_
 23	que	que	SCONJ	_	_	25	mark	_	_
@@ -8797,11 +8796,11 @@
 2	l'	le	DET	_	Definite=Def|Number=Sing|PronType=Art	3	det	_	SpaceAfter=No
 3	organisation	organisation	NOUN	_	Gender=Fem|Number=Sing	5	nsubj	_	_
 4	est	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
-5	libre	libre	ADJ	_	Gender=Fem|Number=Sing	9	advcl	_	SpaceAfter=No
+5	libre	libre	ADJ	_	Gender=Fem|Number=Sing	9	advcl	_	CxnElt=9:Conditional-NeutralEpistemic.Protasis@f|SpaceAfter=No
 6	,	,	PUNCT	_	_	5	punct	_	_
 7	Mgr	Mgr	PROPN	_	_	9	nsubj	_	_
 8	Lebrun	Lebrun	PROPN	_	_	7	flat:name	_	_
-9	insiste	insister	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+9	insiste	insister	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=9:Conditional-NeutralEpistemic.Apodosis@p
 10	sur	sur	ADP	_	_	13	case	_	_
 11	«	«	PUNCT	_	_	13	punct	_	_
 12	deux	deux	NUM	_	Number=Plur	13	nummod	_	_
@@ -8861,7 +8860,7 @@
 9	Premier	premier	ADJ	_	Gender=Masc|Number=Sing	10	amod	_	wordform=premier
 10	ministre	ministre	NOUN	_	Gender=Masc|Number=Sing	12	nsubj	_	_
 11	grec	grec	ADJ	_	Gender=Masc|Number=Sing	10	amod	_	_
-12	va	aller	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	42	advcl	_	_
+12	va	aller	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	42	advcl	_	CxnElt=42:Conditional-NeutralEpistemic.Protasis@f
 13-14	au	_	_	_	_	_	_	_	_
 13	à	à	ADP	_	_	15	case	_	_
 14	le	le	DET	_	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
@@ -8892,7 +8891,7 @@
 39	Euro	Euro	PROPN	_	_	38	nmod	_	_
 40	en	en	PRON	_	Emph=No|Person=3|PronType=Prs	42	obl:mod	_	_
 41	sera	être	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	42	cop	_	_
-42	inéluctable	inéluctable	ADJ	_	Gender=Fem|Number=Sing	0	root	_	_
+42	inéluctable	inéluctable	ADJ	_	Gender=Fem|Number=Sing	0	root	_	Cxn=Conditional-NeutralEpistemic|CxnElt=42:Conditional-NeutralEpistemic.Apodosis@p
 43	et	et	CCONJ	_	_	50	cc	_	SpaceAfter=No
 44	,	,	PUNCT	_	_	46	punct	_	_
 45	par	par	ADP	_	_	46	case	_	_
@@ -11229,7 +11228,7 @@
 43	arc	arc	X	_	Gender=Masc|Number=Sing	42	nmod	_	_
 44	Les	le	DET	_	Definite=Def|Number=Plur|PronType=Art	45	det	_	InTitle=Yes|wordform=les
 45	handicapés	handicapé	NOUN	_	Gender=Masc|Number=Plur	46	nsubj	_	InTitle=Yes
-46	vont	aller	VERB	_	ExtPos=PROPN|Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	42	appos	_	SpaceAfter=No|Title=Yes
+46	vont	aller	VERB	_	ExtPos=PROPN|Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	42	appos	_	Cxn=Interrogative-Polar-Direct|CxnElt=46:Interrogative-Polar-Direct.Clause|SpaceAfter=No|Title=Yes
 47	-ils	eux	PRON	_	Emph=No|Gender=Masc|Number=Plur|Person=3|PronType=Prs	46	expl:subj	_	InTitle=Yes|wordform=ils
 48	en	en	ADP	_	_	49	case	_	InTitle=Yes
 49	enfer	enfer	NOUN	_	Gender=Masc|Number=Sing	46	obl:mod	_	InTitle=Yes


### PR DESCRIPTION
Dear maintainers,

As part of our work for the paper [UCxn: Typologically Informed Annotation of Constructions Atop Universal Dependencies](https://aclanthology.org/2024.lrec-main.1471.pdf), we annotated some constructions atop UD annotations using  rewrite rules for many treebanks, including the this one.

We thought that these annotations could be added for the new the release. The new annotations are concatenated in the MISC column in alphabetical order. I add this change in the changelog of the README. Do you think it will be possible to add them?

Thank you in advance